### PR TITLE
Simple updates for MaxConcurrentRequests

### DIFF
--- a/src/main/scala/scredis/protocol/Protocol.scala
+++ b/src/main/scala/scredis/protocol/Protocol.scala
@@ -55,7 +55,7 @@ object Protocol {
   )
   private val concurrentOpt: Option[(Semaphore, Boolean)] = {
     RedisConfigDefaults.Global.MaxConcurrentRequestsOpt.map { concurrent =>
-      (new Semaphore(30000), true)
+      (new Semaphore(concurrent), true)
     }
   }
   

--- a/src/main/scala/scredis/protocol/Request.scala
+++ b/src/main/scala/scredis/protocol/Request.scala
@@ -49,18 +49,22 @@ abstract class Request[A](command: Command, args: Any*) {
   private[scredis] def success(value: Any): Unit = {
     try {
       promise.success(value.asInstanceOf[A])
-      Protocol.release()
     } catch {
       case e: IllegalStateException =>
+    } finally {
+      // make sure we release a connection
+      Protocol.release()
     }
   }
   
   private[scredis] def failure(throwable: Throwable): Unit = {
     try {
       promise.failure(throwable)
-      Protocol.release()
     } catch {
       case e: IllegalStateException =>
+    } finally {
+      // make sure we release a connection
+      Protocol.release()
     }
   }
   


### PR DESCRIPTION
Hi,
In looking at https://github.com/Livestream/scredis/issues/39 I found that the configured value for maximum connections was not being used.  I also moved the calls to Protocol.release into finally blocks to ensure the semaphore is decremented.

Thanks!
-brandon