### PR TITLE
None out remainingByteStringOpt on receive timeout

### DIFF
--- a/src/main/scala/scredis/io/ListenerActor.scala
+++ b/src/main/scala/scredis/io/ListenerActor.scala
@@ -258,6 +258,7 @@ class ListenerActor(
   protected def handleReceiveTimeout(): Unit = {
     logger.error("Receive timeout")
     isReceiveTimeout = true
+    remainingByteStringOpt = None
     timeoutCancellableOpt = None
     ioActor ! IOActor.Shutdown
     become(reconnecting)


### PR DESCRIPTION
See write up here:

http://techblog.appnexus.com/blog/2015/09/29/the-scredis-driver-malfunctions-in-pathological-environments/
